### PR TITLE
Added api-version and Updated Pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -33,8 +33,8 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>bungee-repo</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
+            <id>bungeecord-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <repository>
             <id>dmulloy2-repo</id>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.62.Final</version>
+            <version>4.1.63.Final</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -4,6 +4,7 @@ main: dev._2lstudios.cleanmotd.bukkit.Main
 description: Simple MotD managing plugin.
 author: 2LS
 softdepend: [ProtocolLib]
+api-version: 1.13
 commands:
   cleanmotd:
     description: "Main CleanMotD command."


### PR DESCRIPTION
When testing some plugins and their compatibility with Java 16(the plugin does work). I noticed that CleanMotD takes up to 2 minutes to load because it doesn't have api-version, according to my local test. Here I add the necessary api-version and update the Bungeecord repository to the recommended one, update the netty version to 4.1.63(bug fix) and the maven-compiler-plugin version.